### PR TITLE
Fix testcontainers at development time app not starting

### DIFF
--- a/src/test/java/jpa/buddy/stockmanagement/TestcontainersConfiguration.java
+++ b/src/test/java/jpa/buddy/stockmanagement/TestcontainersConfiguration.java
@@ -15,6 +15,6 @@ public class TestcontainersConfiguration {
     }
 
     public static void main(String[] args) {
-        SpringApplication.from(TestcontainersConfiguration::main).with(TestcontainersConfiguration.class).run(args);
+        SpringApplication.from(StockManagementApplication::main).with(TestcontainersConfiguration.class).run(args);
     }
 }


### PR DESCRIPTION
As per Spring's blog post [here](https://spring.io/blog/2023/06/23/improved-testcontainers-support-in-spring-boot-3-1#testcontainers-at-development-time), the actual (i.e. non-test) application's main method needs to be referenced, to fire up the testcontainers when running the app itself.